### PR TITLE
Fix extension setup in Firefox Selenium

### DIFF
--- a/src/get.py
+++ b/src/get.py
@@ -8,19 +8,34 @@ from selenium.webdriver.support.ui import WebDriverWait
 BASE_URL = "https://photon-sol.tinyastro.io/en/discover"
 
 options = webdriver.FirefoxOptions()
-options.
-options.add_argument(
-    "--load-extension=/phantom_app-24.26.0.xpi"
-)  # Add this line to include the extension
+options.add_extension("/phantom_app-24.26.0.xpi")  # Add this line to include the extension
 browser = webdriver.Remote(
     command_executor=environ["SELENIUM_HOST"] + "/wd/hub", options=options
 )
+
 try:
     browser.get(BASE_URL)
+    
+    # Log into the extension with user/password
     WebDriverWait(browser, 10).until(
-        EC.visibility_of_element_located(
-            (By.CSS_SELECTOR, "div[data-icon='user-octagon']")
-        )
+        EC.visibility_of_element_located((By.CSS_SELECTOR, "div[data-icon='user-octagon']"))
     )
+    browser.find_element(By.CSS_SELECTOR, "div[data-icon='user-octagon']").click()
+    WebDriverWait(browser, 10).until(
+        EC.visibility_of_element_located((By.CSS_SELECTOR, "input[type='password']"))
+    )
+    browser.find_element(By.CSS_SELECTOR, "input[type='password']").send_keys("your_password")
+    browser.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+    
+    # Log into the website with the given extension/wallet
+    WebDriverWait(browser, 10).until(
+        EC.visibility_of_element_located((By.CSS_SELECTOR, "button[data-id='connect-wallet']"))
+    )
+    browser.find_element(By.CSS_SELECTOR, "button[data-id='connect-wallet']").click()
+    WebDriverWait(browser, 10).until(
+        EC.visibility_of_element_located((By.CSS_SELECTOR, "button[data-id='phantom-wallet']"))
+    )
+    browser.find_element(By.CSS_SELECTOR, "button[data-id='phantom-wallet']").click()
+    
 finally:
     browser.quit()


### PR DESCRIPTION
Update `src/get.py` to correctly add the Firefox extension and log into the website.

* Replace `options.add_argument("--load-extension=/phantom_app-24.26.0.xpi")` with `options.add_extension("/phantom_app-24.26.0.xpi")` to correctly add the extension.
* Add code to log into the extension with user/password.
* Add code to log into the website `https://photon-sol.tinyastro.io/en/discover` with the given extension/wallet.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JustinGuese/pumpfun-sol-website-tracker/pull/1?shareId=7cc2ff8d-c5ce-4f72-8e84-010fbbb688a8).